### PR TITLE
Fix 0.0.0 version in wheel metadata (setuptools-scm)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,13 @@ source:
   sha256: c753cea73f9e803c246e9bf01a59eb652897ed8a19334ada0f968394c7f61650
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   script_env:
     - PYTHON_ZLIB_NG_LINK_DYNAMIC=true  # Forces a dynamic link against zlib-ng in conda-forge
+    # Pin the version so setuptools-scm doesn't resolve the feedstock git tree
+    # in the build sandbox and fall back to 0.0.0 in the wheel metadata.
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
@@ -25,7 +28,7 @@ requirements:
     - setuptools
     - python
     - zlib-ng
-    - versioningit >=1.1.0
+    - setuptools-scm >=8
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
   commands:
     - python -c "from zlib_ng import gzip_ng"
     - python -c "from zlib_ng import zlib_ng; zlib_ng.adler32(b'test')"
+    - python -c "from importlib.metadata import version; assert version('zlib-ng') == '{{ version }}'"
 about:
   home: https://github.com/pycompression/python-zlib-ng
   license: PSF-2.0


### PR DESCRIPTION
Hey @rhpvorderman 

Just patching a small packaging issue I ran into with a downstream conda package that imports xopen. I don't think it's a functional issue, it just causes `pip check` to fail in environments that have installed python-zlib-ng (and python-isal) through conda.

Reprex:

```sh
$ pixi init && pixi add pip python-zlib-ng
$ pixi run pip show zlib-ng | grep Version
```

